### PR TITLE
[RORDEV-1018] reproduction - multitenancy switch issue when xpack.security is enabled

### DIFF
--- a/ror-demo-cluster/conf/elasticsearch.yml
+++ b/ror-demo-cluster/conf/elasticsearch.yml
@@ -2,4 +2,4 @@ cluster.name: ror-cluster
 node.name: ror-es01
 network.host: 0.0.0.0
 
-xpack.security.enabled: false
+xpack.security.enabled: true

--- a/ror-demo-cluster/conf/kibana.yml
+++ b/ror-demo-cluster/conf/kibana.yml
@@ -9,3 +9,9 @@ monitoring.ui.container.elasticsearch.enabled: true
 
 readonlyrest_kbn.logLevel: info
 readonlyrest_kbn.cookiePass: '12312313123213123213123abcdefghijklm'
+
+logging.loggers:
+  ### responses to an HTTP request
+  - name: http.server.response
+    level: debug
+    appenders: [console]

--- a/ror-demo-cluster/conf/readonlyrest.yml
+++ b/ror-demo-cluster/conf/readonlyrest.yml
@@ -20,3 +20,20 @@ readonlyrest:
       indices: [".kibana*", "my*"]
       kibana_access: ro
       kibana_index: '.kibana'
+
+    - name: "Admin Tenancy"
+      groups: ["Admins"]
+      kibana:
+        access: admin
+        index: ".kibana"
+     
+    - name: "Template Tenancy"
+      groups: ["Template"]
+      kibana:
+        access: admin
+        index: ".kibana_template"
+     
+  users:
+    - username: administrator
+      auth_key: administrator:dev
+      groups: ["Admins", "Template"]


### PR DESCRIPTION
<img width="962" alt="Screenshot 2023-10-30 at 21 50 46" src="https://github.com/beshu-tech/ror-sandbox/assets/231553/97ba61ff-e736-4188-bc3f-c27fbcbb9e11">

Steps to reproduce:
1. setup Enterprise license
2. log as `administrator:dev` 
3. change tenancy from "Admins" to "Template"

You should see a raw message in the browser:
```
{"statusCode":500,"error":"Internal Server Error","message":"Invalid response received from Elasticsearch has_privilege endpoint. Error: [application.kibana-.kibana]: Payload did not match expected resources"}
```

