### PR TITLE
[RORDEV-1050] reproduction

### DIFF
--- a/ror-demo-cluster/conf/readonlyrest.yml
+++ b/ror-demo-cluster/conf/readonlyrest.yml
@@ -20,3 +20,9 @@ readonlyrest:
       indices: [".kibana*", "my*"]
       kibana_access: ro
       kibana_index: '.kibana'
+
+    - name: "User 2"
+      type: allow
+      auth_key: "user2:test"
+      indices: ["example"]
+      fields: ["~price"]

--- a/ror-demo-cluster/docker-compose.yml
+++ b/ror-demo-cluster/docker-compose.yml
@@ -57,6 +57,16 @@ services:
         soft: -1
         hard: -1
 
+  python-client:
+    build:
+      context: .
+      dockerfile: images/python-client/Dockerfile
+    depends_on:
+      es-ror:
+        condition: service_healthy
+    networks:
+      - es-ror-network
+
 networks:
   es-ror-network:
     driver: bridge

--- a/ror-demo-cluster/images/python-client/Dockerfile
+++ b/ror-demo-cluster/images/python-client/Dockerfile
@@ -1,0 +1,7 @@
+FROM python
+
+COPY ./images/python-client/setup.sh /tmp/setup.sh
+COPY ./images/python-client/call-es.py /tmp/call-es.py
+
+CMD /tmp/setup.sh && \
+    sleep infinity

--- a/ror-demo-cluster/images/python-client/call-es.py
+++ b/ror-demo-cluster/images/python-client/call-es.py
@@ -1,0 +1,19 @@
+import elasticsearch_dsl, elasticsearch
+from ssl import create_default_context, CERT_NONE
+from elasticsearch_service import ElasticsearchService
+context = create_default_context()
+context.check_hostname = False
+context.verify_mode = CERT_NONE
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+extra = {'scheme':'http','http_auth_username':'user2','http_auth_password':'test', 'ssl_context': context}
+
+es=ElasticsearchService('es-ror', '9200', **extra)
+
+q = elasticsearch_dsl.Q("range", **{"df_date": {"gte": "2023-12-01", "lte": "2024-01-01"}})
+
+returned_data = es.get_documents_with_q('example', query=q)
+
+print(returned_data)
+print(returned_data['price'])

--- a/ror-demo-cluster/images/python-client/setup.sh
+++ b/ror-demo-cluster/images/python-client/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash 
+
+pip install elasticsearch-dsl==7.4.0
+pip install elasticsearch-service
+pip install urllib3==1.26.2
+pip install --upgrade urllib3 six
+pip install requests elasticsearch

--- a/ror-demo-cluster/init-data.sh
+++ b/ror-demo-cluster/init-data.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in $(seq 0 1003); do
+    curl -vk -u kibana:kibana -XPUT "http://localhost:19200/example/_doc/$i" -H "Content-type: application/json" -d '{"df_country": "UK", "price": 100, "df_date": "2023-12-21T11:47:22.992000"}'
+done


### PR DESCRIPTION
Steps to reproduce:

0. `cd ror-demo-cluster/`
1. `./clean.sh && ./run.sh && ./init-data.sh`
2.  Use ES&KBN 7.x and ROR 1.53.0
3. `docker-compose  exec python-client python /tmp/call-es.py`

Result:
```bash
2023-12-01 16:59:18,884 - INFO - elasticsearch_service.elasticsearch_service - log with auth
     df_country                     df_date  price
0            UK  2023-12-21T11:47:22.992000    NaN
1            UK  2023-12-21T11:47:22.992000    NaN
2            UK  2023-12-21T11:47:22.992000    NaN
3            UK  2023-12-21T11:47:22.992000    NaN
4            UK  2023-12-21T11:47:22.992000    NaN
...         ...                         ...    ...
999          UK  2023-12-21T11:47:22.992000    NaN
1000         UK  2023-12-21T11:47:22.992000  100.0
1001         UK  2023-12-21T11:47:22.992000  100.0
1002         UK  2023-12-21T11:47:22.992000  100.0
1003         UK  2023-12-21T11:47:22.992000  100.0

[1004 rows x 3 columns]
0         NaN
1         NaN
2         NaN
3         NaN
4         NaN
        ...
999       NaN
1000    100.0
1001    100.0
1002    100.0
1003    100.0
Name: price, Length: 1004, dtype: float64
```