### PR TITLE
[check] user's configuration

### DIFF
--- a/ror-demo-cluster/conf/readonlyrest.yml
+++ b/ror-demo-cluster/conf/readonlyrest.yml
@@ -1,22 +1,20 @@
 readonlyrest:
 
+  prompt_for_basic_auth: false   
+
   access_control_rules:
 
-    - name: "KIBANA"
-      type: allow
-      auth_key: kibana:kibana
-      verbosity: error
+  - name: "Require HTTP Basic Auth"
+    type: allow
+    auth_key: admin:admin
 
-    - name: "ADMIN"
-      type: allow
-      verbosity: error
-      auth_key: admin:admin
-      kibana_access: admin
-
-    - name: "User 1"
-      type: allow
-      verbosity: error
-      auth_key: "user1:test"
-      indices: [".kibana*", "my*"]
-      kibana_access: ro
-      kibana_index: '.kibana'
+  - name: "::KIBANA-SRV::"
+    auth_key: kibana:kibana
+    
+  - name: "::ADMIN::"
+    type: allow
+    auth_key: admin_usr:dev
+    indices: ["logstash-*"]
+    kibana:
+      access: admin
+  


### PR DESCRIPTION
ref: https://forum.readonlyrest.com/t/unable-to-connect-kibana-to-elasticsearch-after-install-readonlyrest-in-elasticsearch-only/2510/6

<img width="635" alt="Screenshot 2024-03-03 at 20 32 01" src="https://github.com/beshu-tech/ror-sandbox/assets/231553/5bf9f7a0-7c83-4650-bcc6-08be695aa2b3">

http://localhost:15601 (credentials: `admin_usr:dev`)