### PR TITLE
field and groups

### DIFF
--- a/ror-demo-cluster/conf/readonlyrest.yml
+++ b/ror-demo-cluster/conf/readonlyrest.yml
@@ -13,10 +13,18 @@ readonlyrest:
       auth_key: admin:admin
       kibana_access: admin
 
-    - name: "User 1"
-      type: allow
-      verbosity: error
-      auth_key: "user1:test"
-      indices: [".kibana*", "my*"]
-      kibana_access: ro
-      kibana_index: '.kibana'
+    - name: team1
+      groups: [ "team1" ]
+      indices: [ ".kibana*" ]
+    - name: team2
+      groups: [ "team2" ]
+      indices: [ ".kibana*" ]
+      filter: '{"bool": { "must": { "match": { "user": "@{user}" }}}}'
+    - name: team3
+      groups: [ "team3" ]
+      indices: [ ".kibana*" ]
+      fields: ["~excluded_fields_prefix_*", "~excluded_field", "~another_excluded_field.nested_field"]
+  users:
+    - username: test
+      auth_key_unix: test:$6$rounds=65535$d07dnv4N$QeErsDT9Mz.ZoEPXW3dwQGL7tzwRz.eOrTBepIwfGEwdUAYSy/NirGoOaNyPx8lqiR6DYRSsDzVvVbhP4Y9wf0 #test:test
+      groups: [ "team1", "team2", "team2" ]


### PR DESCRIPTION
Steps:
- Activate enterprise version
- Select:
<img width="1113" alt="image" src="https://github.com/beshu-tech/ror-sandbox/assets/9945753/53f2289b-62f3-44b6-b721-42ae14d73109">

- Login as test:test
- Open Kibana menu


There is only one group. Groups where there is a mix of indices and filter/fields are missing