### PR TITLE
[RORDEV-1131] reproduction - `xpack.security.enabled: true` and data views creation

### DIFF
--- a/ror-demo-cluster/conf/elasticsearch.yml
+++ b/ror-demo-cluster/conf/elasticsearch.yml
@@ -2,4 +2,5 @@ cluster.name: ror-cluster
 node.name: ror-es01
 network.host: 0.0.0.0
 
-xpack.security.enabled: false
+# xpack.security.enabled: true # DOESN'T WORK
+xpack.security.enabled: false # WORKS 

--- a/ror-demo-cluster/conf/log4j2.properties
+++ b/ror-demo-cluster/conf/log4j2.properties
@@ -83,3 +83,6 @@ logger.index_indexing_slowlog.additivity=false
 
 appender.header_warning.type = HeaderWarningAppender
 appender.header_warning.name = header_warning
+
+logger.ror.name=tech.beshu.ror
+logger.ror.level=debug

--- a/ror-demo-cluster/conf/readonlyrest.yml
+++ b/ror-demo-cluster/conf/readonlyrest.yml
@@ -5,18 +5,40 @@ readonlyrest:
     - name: "KIBANA"
       type: allow
       auth_key: kibana:kibana
-      verbosity: error
 
-    - name: "ADMIN"
-      type: allow
-      verbosity: error
-      auth_key: admin:admin
-      kibana_access: admin
+    - name: "Full Admin Kibana"
+      groups: ["full-admin"]
+      indices: ["*"]
+      kibana_access: "admin"
 
-    - name: "User 1"
-      type: allow
-      verbosity: error
-      auth_key: "user1:test"
-      indices: [".kibana*", "my*"]
-      kibana_access: ro
-      kibana_index: '.kibana'
+    - name: "Full Admin Users"
+      groups: ["full-admin"]
+      indices: ["*"]
+      actions: ["*"]
+
+    - name: "Client Admin Group Kibana"
+      groups: ["client_admin"]
+      indices: ["kibana_client_admin", "*"]
+      kibana_access: "rw"
+      kibana_index: "kibana_client_admin"
+
+    - name: "Client Admin Group 0"
+      groups: ["client_admin"]
+      indices: ["*"]
+      actions: ["*"]
+
+    - name: "Test Group Kibana"
+      groups: ["test"]
+      indices: ["kibana_test", "*"]
+      kibana_access: "rw"
+      kibana_index: "kibana_test"
+
+    - name: "Test Group 0"
+      groups: ["test"]
+      indices: ["*"]
+      actions: ["*"]
+
+  users:
+    - username: "user1"
+      groups: ["full-admin", "client_admin", "test"]
+      auth_key: user1:test

--- a/ror-demo-cluster/docker-compose.yml
+++ b/ror-demo-cluster/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5000"
       - ES_VERSION=$ES_VERSION
     healthcheck:
-      test: [ "CMD", "curl", "-fk", "-u", "admin:admin", "http://localhost:9200/_cluster/health" ]
+      test: [ "CMD", "curl", "-fk", "-u", "kibana:kibana", "http://localhost:9200/_cluster/health" ]
       interval: 10s
       timeout: 10s
       retries: 30

--- a/ror-demo-cluster/init-data.sh
+++ b/ror-demo-cluster/init-data.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in $(seq 0 100); do
+    curl -vk -u kibana:kibana -XPUT "http://localhost:19200/example/_doc/$i" -H "Content-type: application/json" -d '{"df_country": "UK", "price": 100, "df_date": "2023-12-21T11:47:22.992000"}'
+done


### PR DESCRIPTION
**Steps to reproduce:**

1. set `ROR_ACTIVATION_KEY` (with enterprise license)
2. in `elasticsearch.yml` set `xpack.security.enabled: true`
3. run sandbox: `./clean.sh && ./run.sh && ./init-data.sh`

```bash
  _____                _  ____        _       _____  ______  _____ _______
 |  __ \              | |/ __ \      | |     |  __ \|  ____|/ ____|__   __|
 | |__) |___  __ _  __| | |  | |_ __ | |_   _| |__) | |__  | (___    | |
 |  _  // _ \/ _| |/ _| | |  | | '_ \| | | | |  _  /|  __|  \___ \   | |
 | | \ \  __/ (_| | (_| | |__| | | | | | |_| | | \ \| |____ ____) |  | |
 |_|  \_\___|\__,_|\__,_|\____/|_| |_|_|\__, |_|  \_\______|_____/   |_|
                                         __/ |

Preparing Elasticsearch & Kibana with ROR environment ...
-----------------
Enter Elasticsearch version (default: 8.12.2): 8.6.2
Use ES ROR:
1. From API
2. From FILE

Your choice: 2
Enter ROR Elasticsearch file path (it has to be placed in .): readonlyrest-1.56.0_es8.6.2.zip
-----------------
Enter Kibana version (default: 8.6.2):
Use KBN ROR:
 1. From API
 2. From FILE

Your choice: 1
Enter ROR Kibana version (default: 1.56.0):
-----------------
Starting Elasticsearch and Kibana with installed ROR plugins ...
```

4. open: `http://localhost:15601/s/default/app/management/kibana/dataViews/` and log in as `user1:test`
5. create data view:
  a) name `test01`
  b) pattern `ex*`
  c) timestamp: `df_date`
  
 **Problem:**

 The data view is created using `kibana` user, not `user1`. It can be seen in the ES logs:
 ```
 es-ror-1  | [2024-03-24T12:22:30,938][INFO ][t.b.r.a.l.AccessControlLoggingDecorator] [es-ror-single] [1010] ALLOWED by { name: 'KIBANA', policy: ALLOW, rules: [auth_key] req={ ID:1010, TYP:IndexRequest, CGR:<N/A>, USR:kibana, BRS:true, KDX:null, ACT:indices:data/write/index, OA:172.19.0.3/32, XFF:null, DA:172.19.0.2/32, IDX:.kibana_8.6.2, MET:PUT, PTH:/.kibana_8.6.2/_create/index-pattern:b0eea2e9-0498-43bf-b934-7d12f911c1d5, CNT:{"index-pattern":{"fieldAttrs":"{}","title":"ex*","timeFieldName":"df_date","sourceFilters":"[]","fields":"[]","fieldFormatMap":"{}","typeMeta":"{}","runtimeFieldMap":"{}","name":"test05"},"type":"index-pattern","references":[],"namespaces":["default"],"migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.6.2","updated_at":"2024-03-24T12:22:30.925Z","created_at":"2024-03-24T12:22:30.925Z"}, HDR:Accept-Charset=utf-8, Authorization=Basic a2liYW5hOmtpYmFuYQ==, Host=es-ror:9200, accept=application/vnd.elasticsearch+json; compatible-with=8, connection=keep-alive, content-length=409, content-type=application/vnd.elasticsearch+json; compatible-with=8, elastic-apm-traceparent=00-7a1957862bf523e016386b1a071a6482-cf4a69957cdf2aaa-00, keep-alive=timeout=10, max=1000, traceparent=00-7a1957862bf523e016386b1a071a6482-cf4a69957cdf2aaa-00, tracestate=es=s:0, user-agent=Kibana/8.6.2, x-elastic-client-meta=es=8.4.0p,js=16.18.1,t=8.2.0,hc=16.18.1, x-elastic-product-origin=kibana, x-opaque-id=unknownId, HIS:[KIBANA-> RULES:[auth_key->true] RESOLVED:[user=kibana;indices=.kibana_8.6.2]], }
```

When you set `xpack.security.enabled: false` everything works as expected. The `user1` user is used to create the data view:

```
es-ror-1  | [2024-03-24T12:25:55,175][INFO ][t.b.r.a.l.AccessControlLoggingDecorator] [es-ror-single] [516] ALLOWED by { name: 'Full Admin Kibana', policy: ALLOW, rules: [groups_or,kibana_access,indices] req={ ID:516, TYP:IndexRequest, CGR:full-admin, USR:user1, BRS:true, KDX:.kibana, ACT:indices:data/write/index, OA:172.19.0.3/32, XFF:localhost:15601, DA:172.19.0.2/32, IDX:.kibana, MET:PUT, PTH:/.kibana/_create/index-pattern:56c648f9-004d-4132-8cd8-652dfae669aa, CNT:{"index-pattern":{"fieldAttrs":"{}","title":"ex*","timeFieldName":"df_date","sourceFilters":"[]","fields":"[]","fieldFormatMap":"{}","typeMeta":"{}","runtimeFieldMap":"{}","name":"test06"},"type":"index-pattern","references":[],"namespaces":["default"],"migrationVersion":{"index-pattern":"8.0.0"},"coreMigrationVersion":"8.6.2","updated_at":"2024-03-24T12:25:55.160Z","created_at":"2024-03-24T12:25:55.160Z"}, HDR:Accept-Charset=utf-8, Authorization=Basic dXNlcjE6dGVzdA==, Host=es-ror:9200, accept=application/vnd.elasticsearch+json; compatible-with=8, connection=keep-alive, content-length=409, content-type=application/vnd.elasticsearch+json; compatible-with=8, cookie=x-csrf-token-f23e498b-4b11-49bb-b26a-5d3e5fd4c5e8=08d460db277b92016e09bcffaf1b99802fde49a9e100caac57ec235a44e0f87cf32405db64592140c293e3ee35d93c8e6cf4456ca9e86e3eacbc7eaa79a8c4b3%7C59b5b73722508cc34cba3254a95bfc25738fea95d55d44f31f4d3b20447e458e; x-csrf-token-781e0c77-e621-4c8e-bee9-af167b26045e=08473ed2b5077926c3e8d7447652ab86a1b6c54130e78c07d6b7c1a1898a8949; x-csrf-token-54850ac2-358e-4a8d-8ee9-12d68bde60ba=6b05158e9017ba896de5894ee39181841187ed4e697e41ec53228e4c12314b63d068359c01e7ab53bcc2723b5133fa5d2d37ad8626733481298deec93a83e4e8%7Caeee6476b22a1d6307bd4b5167790488a4f68fe0a04f1f893a14dcd802ee9dbf, elastic-apm-traceparent=00-3cc4d9bbe0eeebce00de6376240fce6a-dc9ca5dd5abf6175-00, keep-alive=timeout=10, max=1000, traceparent=00-3cc4d9bbe0eeebce00de6376240fce6a-dc9ca5dd5abf6175-00, tracestate=es=s:0, user-agent=Kibana/8.6.2, x-elastic-client-meta=es=8.4.0p,js=16.18.1,t=8.2.0,hc=16.18.1, x-elastic-product-origin=kibana, x-forwarded-for=localhost:15601, x-opaque-id=unknownId, x-ror-correlation-id=48a4d155-30ae-4497-adba-9c7076a62fb2, x-ror-current-group=full-admin, x-ror-kibana-index=.kibana, x-ror-kibana-request-method=post, x-ror-kibana-request-path=/s/default/api/saved_objects/index-pattern/56c648f9-004d-4132-8cd8-652dfae669aa, HIS:[KIBANA-> RULES:[auth_key->false] RESOLVED:[group=full-admin;indices=.kibana]], [Full Admin Kibana-> RULES:[groups_or->true, kibana_access->true, indices->true] RESOLVED:[user=user1;group=full-admin;av_groups=full-admin;indices=.kibana;kibana_idx=.kibana]], }
```

**Notes:**

1. the ES plugin used here has additional logging only (you can use 1.56.0 with no problems)
2. I've tested ROR KBN 1.56.0, 1.55.0, 1.54.0 - the issue exists for all these versions