### PR TITLE
feat: enforce LF line breaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Enforcing line breaks to be LF for *.sh files. Without this, the scripts won't work on WSL