### PR TITLE
[Bugfix] using older ROR versions

### DIFF
--- a/ror-demo-cluster/images/kbn/install-ror-kbn-using-api.sh
+++ b/ror-demo-cluster/images/kbn/install-ror-kbn-using-api.sh
@@ -29,8 +29,10 @@ fi
 
 if greater_than_or_equal "$KBN_VERSION" "7.11.0" ; then
   /usr/share/kibana/bin/kibana-plugin install "$ROR_DOWNLOAD_URL"
-else
+elif greater_than_or_equal "$KBN_VERSION" "7.2.0" ; then
   /usr/share/kibana/bin/kibana-plugin install --allow-root "$ROR_DOWNLOAD_URL" 
+else
+  /usr/share/kibana/bin/kibana-plugin install "$ROR_DOWNLOAD_URL"
 fi
 
 if greater_than_or_equal "$KBN_VERSION" "8.15.0" ; then

--- a/utils/collect-info-about-ror-es-kbn-with-hints.sh
+++ b/utils/collect-info-about-ror-es-kbn-with-hints.sh
@@ -11,13 +11,18 @@ determine_ror_es_dockerfile () {
   source .env
 
   PICKED_ES_VERSION=$ES_VERSION
+  DEFAULT_CHOICE=1
 
   while true; do
-    read -p "Use ES ROR:
+    read -p "Use ES ROR (default $DEFAULT_CHOICE):
 1. From API
 2. From FILE
 
 Your choice: " choice
+
+    if [ -z "$choice" ]; then
+      choice=$DEFAULT_CHOICE
+    fi
 
     case "$choice" in
       1 )
@@ -121,13 +126,18 @@ determine_ror_kbn_dockerfile () {
   read_kbn_version "$DEFAULT_KBN_VERSION" "$KBN_VERSIONS_STR"
   source .env
   PICKED_KBN_VERSION=$KBN_VERSION
+  DEFAULT_CHOICE=1
 
   while true; do
-    read -p "Use KBN ROR:
+    read -p "Use KBN ROR (default $DEFAULT_CHOICE):
  1. From API
  2. From FILE
 
 Your choice: " choice
+
+    if [ -z "$choice" ]; then
+      choice=$DEFAULT_CHOICE
+    fi
 
     case "$choice" in
       1 )

--- a/utils/collect-info-about-ror-es-kbn-with-hints.sh
+++ b/utils/collect-info-about-ror-es-kbn-with-hints.sh
@@ -2,11 +2,15 @@
 
 determine_ror_es_dockerfile () {
   ROR_API_RESPONSE=$1
+
   ES_VERSIONS_ARR=($(echo "$ROR_API_RESPONSE" | jq .[0] | jq 'to_entries | map(.value)' | jq .[].esVersions.es -cr | jq .[] -cr | uniq))
   DEFAULT_ES_VERSION=$(echo ${ES_VERSIONS_ARR[0]})
   ES_VERSIONS_STR=$(printf "%s," "${ES_VERSIONS_ARR[@]}")
 
   read_es_version "$DEFAULT_ES_VERSION" "$ES_VERSIONS_STR"
+  source .env
+
+  PICKED_ES_VERSION=$ES_VERSION
 
   while true; do
     read -p "Use ES ROR:
@@ -23,7 +27,7 @@ Your choice: " choice
         DEFAULT_ES_ROR_VERSION=$(echo ${ES_ROR_VERSIONS_ARR[0]})
         ES_ROR_VERSIONS_STR=$(printf "%s," "${ES_ROR_VERSIONS_ARR[@]}")
 
-        read_ror_es_version "$DEFAULT_ES_ROR_VERSION" "$ES_ROR_VERSIONS_STR" "$ROR_API_RESPONSE"
+        read_ror_es_version "$DEFAULT_ES_ROR_VERSION" "$ES_ROR_VERSIONS_STR" "$ROR_API_RESPONSE" "$PICKED_ES_VERSION"
         break
         ;;
       2 )
@@ -64,6 +68,7 @@ read_ror_es_version () {
   DEFAULT_ES_ROR_VERSION=$1
   AVAILABLE_ES_ROR_VERSIONS=$2
   ROR_API_RESPONSE=$3
+  PICKED_ES_VERSION=$4
 
   while true; do
     read -p "Enter ROR Elasticsearch version (default: $DEFAULT_ES_ROR_VERSION): " rorVersion
@@ -76,13 +81,13 @@ read_ror_es_version () {
       ES_VERSIONS_ARR=($(echo "$ROR_API_RESPONSE" | jq .[0] | jq '."'$rorVersion'".esVersions.es[]' -cr))
       for i in "${ES_VERSIONS_ARR[@]}"
       do
-        if [[ $i == "$ES_VERSION" ]]; then
+        if [[ $i == "$PICKED_ES_VERSION" ]]; then
           echo "ROR_ES_VERSION=$rorVersion" >> .env
           break 2
         fi
       done
 
-      echo "ROR Elasticsearch $rorVersion is not available for Elasticsearch $ES_VERSION. Please try again ..."
+      echo "ROR Elasticsearch $rorVersion is not available for Elasticsearch $PICKED_ES_VERSION. Please try again ..."
       continue
     else
       echo "ROR Elasticsearch $rorVersion is not available. Please try again ..."
@@ -107,12 +112,15 @@ read_es_ror_file_path () {
 determine_ror_kbn_dockerfile () {
   ROR_API_RESPONSE=$1
   PICKED_ES_VERSION=$2
+  PICKED_ROR_ES_VERSION=$3
 
   KBN_VERSIONS_ARR=($(echo "$ROR_API_RESPONSE" | jq .[0] | jq 'to_entries | map(.value)' | jq .[].esVersions.kbn_universal -cr | jq .[] -cr | uniq))
   DEFAULT_KBN_VERSION=$PICKED_ES_VERSION
   KBN_VERSIONS_STR=$(printf "%s," "${KBN_VERSIONS_ARR[@]}")
 
   read_kbn_version "$DEFAULT_KBN_VERSION" "$KBN_VERSIONS_STR"
+  source .env
+  PICKED_KBN_VERSION=$KBN_VERSION
 
   while true; do
     read -p "Use KBN ROR:
@@ -126,10 +134,14 @@ Your choice: " choice
         echo "KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api" >> .env
 
         KBN_ROR_VERSIONS_ARR=($(echo "$ROR_API_RESPONSE" | jq .[0] | jq 'to_entries | map(.value)' | jq .[].pluginVersion -cr))
-        DEFAULT_KBN_ROR_VERSION=$(echo ${KBN_ROR_VERSIONS_ARR[0]})
+        if [[ " ${KBN_ROR_VERSIONS_ARR[@]} " =~ " ${PICKED_ROR_ES_VERSION} " ]]; then
+          DEFAULT_KBN_ROR_VERSION=$PICKED_ROR_ES_VERSION
+        else
+          DEFAULT_KBN_ROR_VERSION=${KBN_ROR_VERSIONS_ARR[0]}
+        fi
         KBN_ROR_VERSIONS_STR=$(printf "%s," "${KBN_ROR_VERSIONS_ARR[@]}")
 
-        read_ror_kbn_version "$DEFAULT_KBN_ROR_VERSION" "$KBN_ROR_VERSIONS_STR" "$ROR_API_RESPONSE"
+        read_ror_kbn_version "$DEFAULT_KBN_ROR_VERSION" "$KBN_ROR_VERSIONS_STR" "$ROR_API_RESPONSE" "$PICKED_KBN_VERSION"
         break
         ;;
       2 )
@@ -170,6 +182,7 @@ read_ror_kbn_version () {
   DEFAULT_KBN_ROR_VERSION=$1
   AVAILABLE_KBN_ROR_VERSIONS=$2
   ROR_API_RESPONSE=$3
+  PICKED_KBN_VERSION=$4
 
   while true; do
     read -p "Enter ROR Kibana version (default: $DEFAULT_KBN_ROR_VERSION): " rorVersion
@@ -182,13 +195,13 @@ read_ror_kbn_version () {
       KBN_VERSIONS_ARR=($(echo "$ROR_API_RESPONSE" | jq .[0] | jq '."'$rorVersion'".esVersions.kbn_universal[]' -cr))
       for i in "${KBN_VERSIONS_ARR[@]}"
       do
-        if [[ $i == "$KBN_VERSION" ]]; then
+        if [[ $i == "$PICKED_KBN_VERSION" ]]; then
           echo "ROR_KBN_VERSION=$rorVersion" >> .env
           break 2
         fi
       done
 
-      echo "ROR Kibana $rorVersion is not available for Kibana $KBN_VERSION. Please try again ..."
+      echo "ROR Kibana $rorVersion is not available for Kibana $PICKED_KBN_VERSION. Please try again ..."
       continue
     else
       echo "ROR Kibana $rorVersion is not available. Please try again ..."
@@ -227,5 +240,5 @@ echo "-----------------"
 determine_ror_es_dockerfile "$ROR_API_RESPONSE"
 echo "-----------------"
 source .env
-determine_ror_kbn_dockerfile "$ROR_API_RESPONSE" "$ES_VERSION"
+determine_ror_kbn_dockerfile "$ROR_API_RESPONSE" "$ES_VERSION" "$ROR_ES_VERSION"
 echo "-----------------"


### PR DESCRIPTION
* bugfix: we should be able to use ROR with ES|KBN 7.x
* bugfix: we should be able to use an old version of ROR
* improvement: default for installation method (the API is the default)