### PR TITLE
reproducer no group defined in OIDC user

### DIFF
--- a/ror-demo-cluster/.env-showcase
+++ b/ror-demo-cluster/.env-showcase
@@ -5,10 +5,10 @@
 #   Dockerfile-use-ror-binaries-from-api  - download ROR plugin from API (requires ROR_ES_VERSION / ROR_KBN_VERSION)
 #   Dockerfile-use-ror-binaries-from-file - use a local plugin file (requires ES_ROR_FILE / KBN_ROR_FILE)
 
-#ES_VERSION=8.19.11
-#ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-file
-#ES_ROR_FILE=readonlyrest-1.69.0-pre01_es8.19.11.zip
+ES_VERSION=9.3.3
+ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
+ROR_ES_VERSION=1.68.0
 
-#KBN_VERSION=8.19.11
-#KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-#ROR_KBN_VERSION=1.68.0
+KBN_VERSION=9.3.3
+KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
+ROR_KBN_VERSION=1.68.0

--- a/ror-demo-cluster/.env-showcase
+++ b/ror-demo-cluster/.env-showcase
@@ -7,8 +7,8 @@
 
 ES_VERSION=9.3.3
 ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-ROR_ES_VERSION=1.68.0
+ROR_ES_VERSION=1.69.1
 
 KBN_VERSION=9.3.3
 KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-ROR_KBN_VERSION=1.68.0
+ROR_KBN_VERSION=1.69.1

--- a/ror-demo-cluster/conf/kbn/enterprise-ror-newplatform-kibana.yml
+++ b/ror-demo-cluster/conf/kbn/enterprise-ror-newplatform-kibana.yml
@@ -14,7 +14,7 @@ server.ssl.redirectHttpFromPort: 80
 
 xpack.encryptedSavedObjects.encryptionKey: "min-32-byte-long-strong-encryption-key"
 
-readonlyrest_kbn.logLevel: info
+readonlyrest_kbn.logLevel: trace
 readonlyrest_kbn.cookiePass: '12312313123213123213123abcdefghijklm'
 readonlyrest_kbn:
   auth:

--- a/ror-demo-cluster/conf/keycloak/ror-realm.json
+++ b/ror-demo-cluster/conf/keycloak/ror-realm.json
@@ -151,7 +151,7 @@
       "enabled": true,
       "emailVerified": true,
       "credentials": [ { "type": "password", "value": "extUser1", "temporary": false } ],
-      "groups": ["extEndUsers", "extBusinessUsers"],
+      "groups": [],
       "realmRoles": ["extEndUsers", "extBusinessUsers"]
     },
     {


### PR DESCRIPTION
1. Provide ent activation key
2. Run /bin/bash -e ./ror-demo-cluster/run.sh
3. login via Keycloak OIDC and extUser1:extUser1 (extUser2:extUser2 with groups works as expected)
4. There is an metadata request rejected in logs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Elasticsearch and Kibana to 9.3.3 and bumped ReadonlyREST plugin versions.
  * Switched plugin retrieval to API-based fetching and activated non-interactive config values.
  * Increased ReadonlyREST Kibana logging verbosity to trace.
  * Modified an authentication user’s group membership configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->