### PR TITLE
[RORDEV-2043] stop overwriting stock ES log4j2.properties — use a ROR drop-in instead

### DIFF
--- a/examples/ror-with-kibana-reverse-proxy-demo/conf/es/log4j2.properties
+++ b/examples/ror-with-kibana-reverse-proxy-demo/conf/es/log4j2.properties
@@ -14,72 +14,12 @@
 #     You should have received a copy of the GNU General Public License
 #     along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
 #
-#
-status=error
-# log actionPost execution errors for easier debugging
+# ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+# config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+# config dir).
+
 logger.action.name=org.elasticsearch.action
 logger.action.level=info
-appender.console.type=Console
-appender.console.name=console
-appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-appender.rolling.type=RollingFile
-appender.rolling.name=rolling
-appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-appender.rolling.policies.type=Policies
-appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval=1
-appender.rolling.policies.time.modulate=true
-rootLogger.level=info
-rootLogger.appenderRef.console.ref=console
-rootLogger.appenderRef.rolling.ref=rolling
-appender.deprecation_rolling.type=RollingFile
-appender.deprecation_rolling.name=deprecation_rolling
-appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling.layout.type=PatternLayout
-appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-appender.deprecation_rolling.policies.type=Policies
-appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.size.size=1GB
-appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-appender.deprecation_rolling.strategy.max=4
-logger.deprecation.name = org.elasticsearch.deprecation
-logger.deprecation.level = deprecation
-logger.deprecation.appenderRef.header_warning.ref = header_warning
-logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-logger.deprecation.additivity=false
-appender.index_search_slowlog_rolling.type=RollingFile
-appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-appender.index_search_slowlog_rolling.layout.type=PatternLayout
-appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-appender.index_search_slowlog_rolling.policies.type=Policies
-appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.time.interval=1
-appender.index_search_slowlog_rolling.policies.time.modulate=true
-logger.index_search_slowlog_rolling.name=index.search.slowlog
-logger.index_search_slowlog_rolling.level=trace
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.additivity=false
-appender.index_indexing_slowlog_rolling.type=RollingFile
-appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-appender.index_indexing_slowlog_rolling.policies.type=Policies
-appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.time.interval=1
-appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-logger.index_indexing_slowlog.level=trace
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.additivity=false
 
 logger.ror.name=tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices
 logger.ror.level=info

--- a/examples/ror-with-kibana-reverse-proxy-demo/images/es/Dockerfile-use-ror-binaries-from-api
+++ b/examples/ror-with-kibana-reverse-proxy-demo/images/es/Dockerfile-use-ror-binaries-from-api
@@ -7,7 +7,7 @@ ARG ROR_VERSION=please_set_ror_version_arg
 
 COPY conf/es/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/es/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY conf/es/ror-keystore.jks /usr/share/elasticsearch/config/ror-keystore.jks
 COPY conf/es/ca.crt /usr/share/elasticsearch/config/ca.crt
 COPY conf/es/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt

--- a/examples/ror-with-kibana-reverse-proxy-demo/images/es/Dockerfile-use-ror-binaries-from-file
+++ b/examples/ror-with-kibana-reverse-proxy-demo/images/es/Dockerfile-use-ror-binaries-from-file
@@ -7,7 +7,7 @@ ARG ROR_FILE=please_set_ror_file_path
 
 COPY conf/es/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/es/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY conf/es/ror-keystore.jks /usr/share/elasticsearch/config/ror-keystore.jks
 COPY conf/es/ca.crt /usr/share/elasticsearch/config/ca.crt
 COPY conf/es/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt

--- a/ror-cluster-elastic-cloud-demo/conf/log4j2.properties
+++ b/ror-cluster-elastic-cloud-demo/conf/log4j2.properties
@@ -14,72 +14,9 @@
 #     You should have received a copy of the GNU General Public License
 #     along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
 #
-#
-status=error
-# log actionPost execution errors for easier debugging
+# ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+# config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+# config dir).
+
 logger.action.name=org.elasticsearch.action
 logger.action.level=debug
-appender.console.type=Console
-appender.console.name=console
-appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-appender.rolling.type=RollingFile
-appender.rolling.name=rolling
-appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-appender.rolling.policies.type=Policies
-appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval=1
-appender.rolling.policies.time.modulate=true
-rootLogger.level=info
-rootLogger.appenderRef.console.ref=console
-rootLogger.appenderRef.rolling.ref=rolling
-appender.deprecation_rolling.type=RollingFile
-appender.deprecation_rolling.name=deprecation_rolling
-appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling.layout.type=PatternLayout
-appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-appender.deprecation_rolling.policies.type=Policies
-appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.size.size=1GB
-appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-appender.deprecation_rolling.strategy.max=4
-logger.deprecation.name = org.elasticsearch.deprecation
-logger.deprecation.level = deprecation
-logger.deprecation.appenderRef.header_warning.ref = header_warning
-logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-logger.deprecation.additivity=false
-appender.index_search_slowlog_rolling.type=RollingFile
-appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-appender.index_search_slowlog_rolling.layout.type=PatternLayout
-appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-appender.index_search_slowlog_rolling.policies.type=Policies
-appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.time.interval=1
-appender.index_search_slowlog_rolling.policies.time.modulate=true
-logger.index_search_slowlog_rolling.name=index.search.slowlog
-logger.index_search_slowlog_rolling.level=trace
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.additivity=false
-appender.index_indexing_slowlog_rolling.type=RollingFile
-appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-appender.index_indexing_slowlog_rolling.policies.type=Policies
-appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.time.interval=1
-appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-logger.index_indexing_slowlog.level=trace
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.additivity=false
-
-appender.header_warning.type = HeaderWarningAppender
-appender.header_warning.name = header_warning

--- a/ror-cluster-elastic-cloud-demo/images/es/Dockerfile-use-ror-binaries-from-api
+++ b/ror-cluster-elastic-cloud-demo/images/es/Dockerfile-use-ror-binaries-from-api
@@ -10,7 +10,7 @@ ARG ES_CLOUD_SERVER_NAME
 COPY certs/ /usr/share/elasticsearch/config/
 COPY conf/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY images/es/install-ror-es-using-api.sh /tmp/install-ror.sh
 
 USER root

--- a/ror-cluster-elastic-cloud-demo/images/es/Dockerfile-use-ror-binaries-from-file
+++ b/ror-cluster-elastic-cloud-demo/images/es/Dockerfile-use-ror-binaries-from-file
@@ -10,7 +10,7 @@ ARG ES_CLOUD_SERVER_NAME
 COPY certs/ /usr/share/elasticsearch/config/
 COPY conf/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY images/es/install-ror-es-using-file.sh /tmp/install-ror.sh
 COPY $ROR_FILE /tmp/ror.zip
 

--- a/ror-demo-cluster/conf/es/log4j2.properties
+++ b/ror-demo-cluster/conf/es/log4j2.properties
@@ -14,72 +14,12 @@
 #     You should have received a copy of the GNU General Public License
 #     along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
 #
-#
-status=error
-# log actionPost execution errors for easier debugging
+# ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+# config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+# config dir).
+
 logger.action.name=org.elasticsearch.action
 logger.action.level=info
-appender.console.type=Console
-appender.console.name=console
-appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-appender.rolling.type=RollingFile
-appender.rolling.name=rolling
-appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-appender.rolling.policies.type=Policies
-appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval=1
-appender.rolling.policies.time.modulate=true
-rootLogger.level=info
-rootLogger.appenderRef.console.ref=console
-rootLogger.appenderRef.rolling.ref=rolling
-appender.deprecation_rolling.type=RollingFile
-appender.deprecation_rolling.name=deprecation_rolling
-appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling.layout.type=PatternLayout
-appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-appender.deprecation_rolling.policies.type=Policies
-appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.size.size=1GB
-appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-appender.deprecation_rolling.strategy.max=4
-logger.deprecation.name = org.elasticsearch.deprecation
-logger.deprecation.level = deprecation
-logger.deprecation.appenderRef.header_warning.ref = header_warning
-logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-logger.deprecation.additivity=false
-appender.index_search_slowlog_rolling.type=RollingFile
-appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-appender.index_search_slowlog_rolling.layout.type=PatternLayout
-appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-appender.index_search_slowlog_rolling.policies.type=Policies
-appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.time.interval=1
-appender.index_search_slowlog_rolling.policies.time.modulate=true
-logger.index_search_slowlog_rolling.name=index.search.slowlog
-logger.index_search_slowlog_rolling.level=trace
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.additivity=false
-appender.index_indexing_slowlog_rolling.type=RollingFile
-appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-appender.index_indexing_slowlog_rolling.policies.type=Policies
-appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.time.interval=1
-appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-logger.index_indexing_slowlog.level=trace
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.additivity=false
 
 logger.ror.name=tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices
 logger.ror.level=info

--- a/ror-demo-cluster/images/es/Dockerfile-use-ror-binaries-from-api
+++ b/ror-demo-cluster/images/es/Dockerfile-use-ror-binaries-from-api
@@ -7,7 +7,7 @@ ARG ROR_VERSION=please_set_ror_version_arg
 
 COPY conf/es/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/es/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY conf/es/ror-keystore.jks /usr/share/elasticsearch/config/ror-keystore.jks
 COPY conf/es/ca.crt /usr/share/elasticsearch/config/ca.crt
 COPY conf/es/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt

--- a/ror-demo-cluster/images/es/Dockerfile-use-ror-binaries-from-file
+++ b/ror-demo-cluster/images/es/Dockerfile-use-ror-binaries-from-file
@@ -7,7 +7,7 @@ ARG ROR_FILE=please_set_ror_file_path
 
 COPY conf/es/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/es/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY conf/es/ror-keystore.jks /usr/share/elasticsearch/config/ror-keystore.jks
 COPY conf/es/ca.crt /usr/share/elasticsearch/config/ca.crt
 COPY conf/es/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt

--- a/xpack-docker-demo-cluster/conf/log4j2.properties
+++ b/xpack-docker-demo-cluster/conf/log4j2.properties
@@ -14,72 +14,12 @@
 #     You should have received a copy of the GNU General Public License
 #     along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
 #
-#
-status=error
-# log actionPost execution errors for easier debugging
+# ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+# config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+# config dir).
+
+# NOTE: this env previously set a blanket rootLogger.level=debug; in the drop-in/stock model
+# the root logger stays at the stock level. The action logger is carried over at debug below.
+
 logger.action.name=org.elasticsearch.action
 logger.action.level=debug
-appender.console.type=Console
-appender.console.name=console
-appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-appender.rolling.type=RollingFile
-appender.rolling.name=rolling
-appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-appender.rolling.policies.type=Policies
-appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval=1
-appender.rolling.policies.time.modulate=true
-rootLogger.level=debug
-rootLogger.appenderRef.console.ref=console
-rootLogger.appenderRef.rolling.ref=rolling
-appender.deprecation_rolling.type=RollingFile
-appender.deprecation_rolling.name=deprecation_rolling
-appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling.layout.type=PatternLayout
-appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-appender.deprecation_rolling.policies.type=Policies
-appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.size.size=1GB
-appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-appender.deprecation_rolling.strategy.max=4
-logger.deprecation.name = org.elasticsearch.deprecation
-logger.deprecation.level = deprecation
-logger.deprecation.appenderRef.header_warning.ref = header_warning
-logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-logger.deprecation.additivity=false
-appender.index_search_slowlog_rolling.type=RollingFile
-appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-appender.index_search_slowlog_rolling.layout.type=PatternLayout
-appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-appender.index_search_slowlog_rolling.policies.type=Policies
-appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.time.interval=1
-appender.index_search_slowlog_rolling.policies.time.modulate=true
-logger.index_search_slowlog_rolling.name=index.search.slowlog
-logger.index_search_slowlog_rolling.level=trace
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.additivity=false
-appender.index_indexing_slowlog_rolling.type=RollingFile
-appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-appender.index_indexing_slowlog_rolling.policies.type=Policies
-appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.time.interval=1
-appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-logger.index_indexing_slowlog.level=trace
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.additivity=false
-
-appender.header_warning.type = HeaderWarningAppender
-appender.header_warning.name = header_warning

--- a/xpack-docker-demo-cluster/images/es/Dockerfile
+++ b/xpack-docker-demo-cluster/images/es/Dockerfile
@@ -6,7 +6,7 @@ ARG ES_VERSION
 
 USER elasticsearch
 COPY conf/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY conf/elastic-certificates.p12 /usr/share/elasticsearch/config/elastic-certificates.p12
 
 RUN echo "" | /usr/share/elasticsearch/bin/elasticsearch-keystore create &&\


### PR DESCRIPTION
ES 8.18+ (Entitlements framework) ships a suppression for the entitlements logger in its stock config/log4j2.properties. Our full-file copy was stale and dropped that suppression, flooding logs with benign "Not entitled" warnings from x-pack's file watcher.

ES's LogConfigurator recursively merges every file named log4j2.properties under the config dir, so we can add a drop-in at config/ror/log4j2.properties that declares only our extra loggers. The stock file stays untouched — including the entitlement suppression.