### PR TITLE
[RORDEV_2109] reproduction

### DIFF
--- a/ror-demo-cluster/.env-showcase
+++ b/ror-demo-cluster/.env-showcase
@@ -5,10 +5,10 @@
 #   Dockerfile-use-ror-binaries-from-api  - download ROR plugin from API (requires ROR_ES_VERSION / ROR_KBN_VERSION)
 #   Dockerfile-use-ror-binaries-from-file - use a local plugin file (requires ES_ROR_FILE / KBN_ROR_FILE)
 
-#ES_VERSION=8.19.11
-#ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-file
-#ES_ROR_FILE=readonlyrest-1.69.0-pre01_es8.19.11.zip
+ES_VERSION=8.19.9
+ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
+ROR_ES_VERSION=1.69.1
 
-#KBN_VERSION=8.19.11
-#KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-#ROR_KBN_VERSION=1.68.0
+KBN_VERSION=8.19.9
+KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
+ROR_KBN_VERSION=1.69.1

--- a/ror-demo-cluster/.env-showcase
+++ b/ror-demo-cluster/.env-showcase
@@ -5,10 +5,10 @@
 #   Dockerfile-use-ror-binaries-from-api  - download ROR plugin from API (requires ROR_ES_VERSION / ROR_KBN_VERSION)
 #   Dockerfile-use-ror-binaries-from-file - use a local plugin file (requires ES_ROR_FILE / KBN_ROR_FILE)
 
-ES_VERSION=8.19.9
+ES_VERSION=8.18.3
 ES_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-ROR_ES_VERSION=1.69.1
+ROR_ES_VERSION=1.68.0
 
-KBN_VERSION=8.19.9
+KBN_VERSION=8.18.3
 KBN_DOCKERFILE=Dockerfile-use-ror-binaries-from-api
-ROR_KBN_VERSION=1.69.1
+ROR_KBN_VERSION=1.68.0

--- a/ror-demo-cluster/conf/es-remote/init-remote-indices.sh
+++ b/ror-demo-cluster/conf/es-remote/init-remote-indices.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -e
+# Seeds test indices on the REMOTE cluster during stack init.
+# Run by the 'remote-initializer' one-shot service (see docker-compose.yml).
+# The remote ROR config is permissive (match-all), so no credentials are needed.
+
+ADDR="${REMOTE_ES_ADDRESS:-https://es-remote:9200}"
+
+# es-remote healthcheck gates this via depends_on, but retry a bit just in case.
+for i in $(seq 1 30); do
+  if curl -ks "$ADDR/_cluster/health" >/dev/null 2>&1; then break; fi
+  echo "waiting for remote ES ($i) ..."
+  sleep 5
+done
+
+# 'asdasd' is the index the /*:*asdasd/_search test resolves to. The others let
+# you probe each ACL pattern independently; 'notmatching' is a negative control.
+for idx in asdasd xasdasd asdasdx xasdasdx notmatching; do
+  curl -ks -X PUT "$ADDR/$idx" -H 'Content-Type: application/json' -d '{}' >/dev/null || true
+  curl -ks -X POST "$ADDR/$idx/_doc?refresh=true" -H 'Content-Type: application/json' -d '{"hello":"world"}' >/dev/null || true
+  echo "created remote index: $idx"
+done
+
+echo "remote index init done"

--- a/ror-demo-cluster/conf/es-remote/readonlyrest.yml
+++ b/ror-demo-cluster/conf/es-remote/readonlyrest.yml
@@ -1,0 +1,12 @@
+readonlyrest:
+
+  # Permissive config for the REMOTE test cluster only.
+  # A single match-all block ('actions: ["*"]') allows every request, including:
+  #  - the main cluster's internal cross-cluster _resolve/index call
+  #    (carries an xpack node-authentication header), and
+  #  - the forwarded search phase (carries the original user).
+  # Do NOT use this in production - it disables all access control.
+  access_control_rules:
+
+    - name: "REMOTE TEST CLUSTER - allow everything (test only)"
+      actions: ["*"]

--- a/ror-demo-cluster/conf/es/readonlyrest.yml
+++ b/ror-demo-cluster/conf/es/readonlyrest.yml
@@ -11,25 +11,25 @@ readonlyrest:
       auth_key: kibana:kibana
       verbosity: error
 
-    - name: "Test1"
-      auth_key: user:test
-      indices: ["*:asdasd"]
-      headers: ["test:1"]
+    - name: "Test remote"
+      auth_key: user1:test
+      indices: ["*:asdasd", "*:*asdasd", "*:asdasd*", "*:*asdasd*"]
 
-    - name: "Test2"
-      auth_key: user:test
-      indices: ["*:*asdasd"]
-      headers: ["test:2"]
+    - name: "Test remote (forbid)"
+      type:
+        policy: forbid
+        response_message: "test"
+      auth_key: user1:test
 
-    - name: "Test3"
-      auth_key: user:test
-      indices: ["*:asdasd*"]
-      headers: ["test:3"]
+    - name: "Test local"
+      auth_key: user2:test
+      indices: ["asdasd", "*asdasd", "asdasd*", "*asdasd*"]
 
-    - name: "Test4"
-      auth_key: user:test
-      indices: ["*:*asdasd*"]
-      headers: ["test:4"]
+    - name: "Test local (forbid)"
+      type:
+        policy: forbid
+        response_message: "test"
+      auth_key: user2:test
 
     - name: "Admins"
       auth_key: admin:admin

--- a/ror-demo-cluster/conf/es/readonlyrest.yml
+++ b/ror-demo-cluster/conf/es/readonlyrest.yml
@@ -11,66 +11,27 @@ readonlyrest:
       auth_key: kibana:kibana
       verbosity: error
 
+    - name: "Test1"
+      auth_key: user:test
+      indices: ["*:asdasd"]
+      headers: ["test:1"]
+
+    - name: "Test2"
+      auth_key: user:test
+      indices: ["*:*asdasd"]
+      headers: ["test:2"]
+
+    - name: "Test3"
+      auth_key: user:test
+      indices: ["*:asdasd*"]
+      headers: ["test:3"]
+
+    - name: "Test4"
+      auth_key: user:test
+      indices: ["*:*asdasd*"]
+      headers: ["test:4"]
+
     - name: "Admins"
-      groups: [Administrators]
+      auth_key: admin:admin
       kibana:
         access: admin
-
-    - name: "End users"
-      groups: ["EndUsers"]
-      indices: ["*-frontend-*", "kibana_sample_data_*"]
-      kibana:
-        index: .kibana_end_@{user}
-        access: rw
-        hide_apps: ["Security", "Observability"]
-
-    - name: "Business users"
-      groups: ["BusinessUsers"]
-      indices: ["*-business-*", "kibana_sample_data_*"]
-      kibana:
-        index: .kibana_business_@{user}
-        access: ro
-        hide_apps: ["Security", "Observability"]
-
-  users:
-    - username: admin
-      auth_key: admin:admin
-      groups:
-        - id: "Administrators"
-          name: "Administrators"
-        - id: "EndUsers"
-          name: "End Users"
-        - id: "BusinessUsers"
-          name: "Business Users"
-
-    - username: user1
-      auth_key: user1:test
-      groups:
-        - id: "EndUsers"
-          name: "End Users"
-        - id: "BusinessUsers"
-          name: "Business Users"
-
-    - username: user2
-      auth_key: user2:test
-      groups:
-        - id: "EndUsers"
-          name: "End Users"
-
-    - username: "*"
-      ror_kbn_auth:
-        name: "kbn1"
-        groups: ["*"]
-      groups:
-        - local_group:
-            id: "EndUsers"
-            name: "End Users"
-          external_group_ids: [ "extEndUsers" ]
-        - local_group:
-            id: "BusinessUsers"
-            name: "Business Users"
-          external_group_ids: [ "extBusinessUsers" ]
-
-  ror_kbn:
-    - name: kbn1
-      signature_key: "9yzBfnLaTYLfGPzyKW9es76RKYhUVgmuv6ZtehaScj5msGpBpa5FWpwk295uJYaaffTFnQC5tsknh2AguVDaTrqCLfM5zCTqdE4UGNL73h28Bg4dPrvTAFQyygQqv4xfgnevBED6VZYdfjXAQLc8J8ywaHQQSmprZqYCWGE6sM3vzNUEWWB3kmGrEKa4sGbXhmXZCvL6NDnEJhXPDJAzu9BMQxn8CzVLqrx6BxDgPYF8gZCxtyxMckXwCaYXrxAGbjkYH69F4wYhuAdHSWgRAQCuWwYmWCA6g39j4VPge5pv962XYvxwJpvn23Y5KvNZ5S5c6crdG4f4gTCXnU36x92fKMQzsQV9K4phcuNvMWkpqVB6xMA5aPzUeHcGytD93dG8D52P5BxsgaJJE6QqDrk3Y2vyLw9ZEbJhPRJxbuBKVCBtVx26Ldd46dq5eyyzmNEyQGLrjQ4qd978VtG8TNT5rkn4ETJQEju5HfCBbjm3urGLFVqxhGVawecT4YM9Rry4EqXWkRJGTFQWQRnweUFbKNbVTC9NxcXEp6K5rSPEy9trb5UYLYhhMJ9fWSBMuenGRjNSJxeurMRCaxPpNppBLFnp8qW5ezfHgCBpEjkSNNzP4uXMZFAXmdUfJ8XQdPTWuYfdHYc5TZWnzrdq9wcfFQRDpDB2zX5Myu96krDt9vA7wNKfYwkSczA6qUQV66jA8nV4Cs38cDAKVBXnxz22ddAVrPv8ajpu7hgBtULMURjvLt94Nc5FDKw79CTTQxffWEj9BJCDCpQnTufmT8xenywwVJvtj49yv2MP2mGECrVDRmcGUAYBKR8G6ZnFAYDVC9UhY46FGWDcyVX3HKwgtHeb45Ww7dsW8JdMnZYctaEU585GZmqTJp2LcAWRcQPH25JewnPX8pjzVpJNcy7avfA2bcU86bfASvQBDUCrhjgRmK2ECR6vzPwTsYKRgFrDqb62FeMdrKgJ9vKs435T5ACN7MNtdRXHQ4fj5pNpUMDW26Wd7tt9bkBTqEGf"

--- a/ror-demo-cluster/docker-compose.yml
+++ b/ror-demo-cluster/docker-compose.yml
@@ -115,47 +115,12 @@ services:
     networks:
       - es-ror-network
 
-  kbn-ror:
-    build:
-      context: .
-      dockerfile: images/kbn/${KBN_DOCKERFILE:-KBN_DOCKERFILE_NOT_CONFIGURED}
-      args:
-        KBN_VERSION: ${KBN_VERSION:-KBN_VERSION_NOT_CONFIGURED}
-        ROR_VERSION: ${ROR_KBN_VERSION:-ROR_KBN_VERSION_NOT_CONFIGURED}
-        ROR_FILE: ${KBN_ROR_FILE:-KBN_ROR_FILE_NOT_CONFIGURED}
-        ROR_LICENSE_EDITION: ${ROR_LICENSE_EDITION:-ROR_LICENSE_EDITION_NOT_CONFIGURED}
-    depends_on:
-      es-ror:
-        condition: service_healthy
-      keycloak:
-        condition: service_healthy
-        required: false
-    ports:
-      - "15601:5601"
-    environment:
-      ELASTICSEARCH_HOSTS: https://es-ror:9200
-      ROR_ACTIVATION_KEY: $ROR_ACTIVATION_KEY
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fksS --connect-timeout 3 --max-time 5 --retry 2 --retry-connrefused -u admin:admin https://127.0.0.1:5601/api/features >/dev/null || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 30
-      start_period: 60s
-    networks:
-      - es-ror-network
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-
   initializer:
     build:
       context: .
       dockerfile: images/cluster-initializer/Dockerfile
     depends_on:
       es-ror:
-        condition: service_healthy
-      kbn-ror:
         condition: service_healthy
     environment:
       ELASTICSEARCH_ADDRESS: https://es-ror:9200

--- a/ror-demo-cluster/docker-compose.yml
+++ b/ror-demo-cluster/docker-compose.yml
@@ -42,6 +42,11 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Dcom.readonlyrest.settings.loading.attempts.count=1 -Dcom.readonlyrest.settings.loading.delay=1"
       - ES_VERSION=${ES_VERSION:-ES_VERSION_NOT_CONFIGURED}
+      # Cross-cluster search: register the 'es-remote' node as remote cluster 'remote1'.
+      # This makes ROR see remote clusters as configured, so 'skipRemoteIndicesIfNeeded'
+      # no longer rewrites 'cluster:index' requests into a nonexistent local index.
+      - cluster.remote.remote1.mode=proxy
+      - cluster.remote.remote1.proxy_address=es-remote:9300
     healthcheck:
       test: ["CMD-SHELL", "curl -fksS --connect-timeout 3 --max-time 5 --retry 2 --retry-connrefused -u admin:admin https://127.0.0.1:9200/_cluster/health >/dev/null || exit 1"]
       interval: 10s
@@ -54,6 +59,61 @@ services:
       memlock:
         soft: -1
         hard: -1
+
+  # Second ES node acting as the REMOTE cluster for cross-cluster search tests.
+  # Same image (ROR + certs) as es-ror, different cluster/node name, permissive ROR config.
+  es-remote:
+    build:
+      context: .
+      dockerfile: images/es/${ES_DOCKERFILE:-ES_DOCKERFILE_NOT_CONFIGURED}
+      args:
+        ES_VERSION: ${ES_VERSION:-ES_VERSION_NOT_CONFIGURED}
+        ROR_VERSION: ${ROR_ES_VERSION:-ROR_ES_VERSION_NOT_CONFIGURED}
+        ROR_FILE: ${ES_ROR_FILE:-ES_ROR_FILE_NOT_CONFIGURED}
+    ports:
+      - "29200:9200"
+      - "29300:9300"
+    environment:
+      - cluster.name=ror-remote-cluster
+      - node.name=es-remote-single
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m -Dcom.readonlyrest.settings.loading.attempts.count=1 -Dcom.readonlyrest.settings.loading.delay=1"
+      - ES_VERSION=${ES_VERSION:-ES_VERSION_NOT_CONFIGURED}
+    volumes:
+      # Override the baked-in ACL with a permissive one so the main cluster's internal
+      # cross-cluster resolve/search calls are always allowed on the remote.
+      - ./conf/es-remote/readonlyrest.yml:/usr/share/elasticsearch/config/readonlyrest.yml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fksS --connect-timeout 3 --max-time 5 --retry 2 --retry-connrefused -u admin:admin https://127.0.0.1:9200/_cluster/health >/dev/null || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 60s
+    networks:
+      - es-ror-network
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+
+  # One-shot job: seeds test indices on the remote cluster during stack init.
+  # Reuses the cluster-initializer image (curl+jq) but runs a custom script.
+  remote-initializer:
+    build:
+      context: .
+      dockerfile: images/cluster-initializer/Dockerfile
+    depends_on:
+      es-remote:
+        condition: service_healthy
+    entrypoint: ["/bin/bash", "/init-remote-indices.sh"]
+    environment:
+      REMOTE_ES_ADDRESS: https://es-remote:9200
+    volumes:
+      - ./conf/es-remote/init-remote-indices.sh:/init-remote-indices.sh:ro
+    restart: "no"
+    networks:
+      - es-ror-network
 
   kbn-ror:
     build:

--- a/ror-demo-cluster/test-remote-ccs.sh
+++ b/ror-demo-cluster/test-remote-ccs.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Cross-cluster search test helper for the RORDEV-2109 investigation.
+#
+# Prereqs: `./run.sh` is up and healthy (es-ror + es-remote both running).
+#
+# It:
+#   1. creates real indices on the REMOTE cluster,
+#   2. shows that the main cluster sees the remote as connected,
+#   3. fires the 4 Test blocks (request index is always `*:*asdasd`).
+#
+# Compare against the no-remote-cluster run: previously every block returned
+# IDX_NOT_FOUND because ROR rewrote `*:*asdasd` into a nonexistent local index
+# (skipRemoteIndicesIfNeeded). With a remote cluster configured, `*:*asdasd`
+# now resolves against the real remote indices below.
+
+set -euo pipefail
+
+MAIN="https://127.0.0.1:19200"
+REMOTE="https://127.0.0.1:29200"
+
+echo "== 1. Create test indices on the REMOTE cluster (remote1) =="
+# 'asdasd' is the one matched by the request `*:*asdasd`. The others let you
+# probe the four ACL patterns independently if you change the request.
+for idx in asdasd xasdasd asdasdx xasdasdx notmatching; do
+  curl -ks -X PUT "$REMOTE/$idx" -H 'Content-Type: application/json' -d '{}' >/dev/null || true
+  curl -ks -X POST "$REMOTE/$idx/_doc?refresh=true" -H 'Content-Type: application/json' -d '{"hello":"world"}' >/dev/null || true
+  echo "  created remote index: $idx"
+done
+
+echo
+echo "== 2. Remote cluster connection status (as seen by the MAIN cluster) =="
+curl -ks -u admin:admin "$MAIN/_remote/info?pretty" || true
+
+echo
+echo "== 3. Fire the 4 Test blocks — request index is always /*:*asdasd/_search =="
+echo "   (Test1 indices:[*:asdasd]  Test2:[*:*asdasd]  Test3:[*:asdasd*]  Test4:[*:*asdasd*])"
+for x in 1 2 3 4; do
+  code=$(curl -ks -u user:test "$MAIN/*:*asdasd/_search" -H "test:$x" -o /dev/null -w "%{http_code}")
+  hits=$(curl -ks -u user:test "$MAIN/*:*asdasd/_search" -H "test:$x" | grep -o '"total":{"value":[0-9]*' | head -1 || true)
+  echo "  Test$x -> HTTP $code   $hits"
+done
+
+echo
+echo "Done. HTTP 200 means the indices rule matched (block allowed the request);"
+echo "HTTP 403/401 or an IDX_NOT_FOUND in ror-cluster.log means it did not."

--- a/shared/init-scripts/init.sh
+++ b/shared/init-scripts/init.sh
@@ -6,12 +6,18 @@ cd "$(dirname "$0")"
 
 source utils/lib.sh
 
-createDataStream "logs-frontend-dev" && generate_log_documents 100 | putDocument "logs-frontend-dev"
-createDataStream "logs-business-dev" && generate_log_documents 100 | putDocument "logs-business-dev"
-createDataStream "logs-system-dev" && generate_log_documents 100 | putDocument "logs-system-dev"
+#createDataStream "logs-frontend-dev" && generate_log_documents 100 | putDocument "logs-frontend-dev"
+#createDataStream "logs-business-dev" && generate_log_documents 100 | putDocument "logs-business-dev"
+#createDataStream "logs-system-dev" && generate_log_documents 100 | putDocument "logs-system-dev"
 
 #createKibanaDataView "logs-frontend-*" "Frontend logs" "@timestamp" "admin" "admin" "EndUsers"
 #createKibanaDataView "logs-business-*" "Business logs" "@timestamp" "admin" "admin" "BusinessUsers"
 #createKibanaDataView "logs-system-*" "System logs" "@timestamp" "admin" "admin" "Administrators"
 
-createIndex "data-business-index" && generate_log_documents 100 | putDocument "data-business-index"
+#createIndex "data-business-index" && generate_log_documents 100 | putDocument "data-business-index"
+
+createIndex "asdasd" && generate_log_documents 1 | putDocument "asdasd"
+createIndex "xasdasd" && generate_log_documents 1 | putDocument "xasdasd"
+createIndex "asdasdx" && generate_log_documents 1 | putDocument "asdasdx"
+createIndex "xasdasdx" && generate_log_documents 1 | putDocument "xasdasdx"
+createIndex "notmatching" && generate_log_documents 1 | putDocument "notmatching"


### PR DESCRIPTION
## Running

`cd ror-demo-cluster &&  ./clean.sh && ./run.sh`

You can change ROR and ES/KBN versions in the `.env-showcase` file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a remote Elasticsearch cluster setup for cross-cluster search testing.
  * Included a helper script to initialize remote test indices and verify search behavior.
  * Expanded seeded test data with additional index patterns for remote search scenarios.

* **Bug Fixes**
  * Updated demo access rules to use explicit credentials-based policies.
  * Adjusted startup timing so initialization waits only for the main search cluster.
  * Enabled remote search access with a permissive rule set for test workflows.

* **Chores**
  * Updated showcase versions and binary download settings to the latest release set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->